### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/xboot-fast/pom.xml
+++ b/xboot-fast/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.25</version>
+            <version>8.0.28</version>
         </dependency>
         <!-- JPA -->
         <dependency>

--- a/xboot-module/pom.xml
+++ b/xboot-module/pom.xml
@@ -26,7 +26,7 @@
         <spring.boot.admin.version>2.4.2</spring.boot.admin.version>
         <druid.version>1.2.6</druid.version>
         <jjwt.version>0.9.1</jjwt.version>
-        <mysql.connector.version>8.0.25</mysql.connector.version>
+        <mysql.connector.version>8.0.28</mysql.connector.version>
         <mybatis.plus.version>3.4.3.1</mybatis.plus.version>
         <redission.version>3.15.6</redission.version>
         <knife4j.version>2.0.8</knife4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 8.0.25
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.25 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS